### PR TITLE
Decrease visual font size of footnotes

### DIFF
--- a/Preferences/Footnote.tmPreferences
+++ b/Preferences/Footnote.tmPreferences
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Footnote</string>
+	<key>scope</key>
+	<string>meta.footnote.latex</string>
+	<key>settings</key>
+	<dict>
+		<key>fontName</key>
+		<string>Baskerville</string>
+		<key>fontSize</key>
+		<string>0.85em</string>
+	</dict>
+	<key>uuid</key>
+	<string>9633203E-748B-467B-B299-BE368BDF42C6</string>
+</dict>
+</plist>

--- a/Preferences/Footnote.tmPreferences
+++ b/Preferences/Footnote.tmPreferences
@@ -5,7 +5,7 @@
 	<key>name</key>
 	<string>Footnote</string>
 	<key>scope</key>
-	<string>meta.footnote.latex</string>
+	<string>meta.footnote.latex, support.function.footnote.latex, punctuation.definition.footnote.begin.latex, punctuation.definition.footnote.end.latex</string>
 	<key>settings</key>
 	<dict>
 		<key>background</key>

--- a/Preferences/Footnote.tmPreferences
+++ b/Preferences/Footnote.tmPreferences
@@ -8,6 +8,8 @@
 	<string>meta.footnote.latex</string>
 	<key>settings</key>
 	<dict>
+		<key>background</key>
+		<string>#0000000D</string>
 		<key>fontName</key>
 		<string>Baskerville</string>
 		<key>fontSize</key>


### PR DESCRIPTION
Hi Bret,

this commit should fix issue #5. If you have any suggestions for changes please just comment below.

Kind regards,
  René

P.S.: Here is a a sample screenshot:

![footnote](https://cloud.githubusercontent.com/assets/691989/6905246/0032b1a0-d727-11e4-8966-9652b0c414a0.png)
